### PR TITLE
Feat: `include-versions` options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,14 @@ jobs:
         simulate: true
         min-versions-to-keep: 5
         ignore-versions: '^(?!999)(\d+)\.(\d+)\.(\d+)$'
+
+    - uses: ./
+      name: Include version
+      with:
+        owner: 'creadigme'
+        package-name: 'au-i18n-audit'
+        package-type: 'npm'
+        verbose: true
+        simulate: true
+        min-versions-to-keep: 5
+        include-versions: '^999\.'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
 # Usage
 
 ```yaml
-- uses: aegenet/delete-package-versions@v5.3.0
+- uses: aegenet/delete-package-versions@v5.4.0
   with:
   # Can be a single package version id, or a comma separated list of package version ids.
   # Defaults to an empty string.
@@ -55,6 +55,11 @@ This is a fork of https://github.com/actions/delete-package-versions.
   # Takes regex for the version name as input.
   # By default nothing is ignored. This is ignored when `delete-only-pre-release-versions` is true
   ignore-versions:
+
+  # The package versions to include from deletion.
+  # Takes regex for the version name as input.
+  # By default all versions are included
+  include-versions:
 
   # If true it will delete only the pre-release versions.
   # The number of pre-release versions to keep can be set by using `min-versions-to-keep` value with this.
@@ -132,7 +137,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete all pre-release package versions except latest 10
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with: 
       package-name: 'test-package'
       package-type: 'npm'
@@ -146,7 +151,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete all pre-release package versions except latest 10 from a repo not having access to package
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with: 
       owner: 'github'
       package-name: 'test-package'
@@ -167,7 +172,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete all untagged versions except latest 10
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with: 
       package-name: 'test-package'
       package-type: 'container'
@@ -186,7 +191,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete all except latest 3 package versions excluding major versions as per semver
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with: 
       package-name: 'test-package'
       package-type: 'npm'
@@ -203,7 +208,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete all except latest 3 package versions excluding major versions as per semver from a repo not having access to package
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with: 
       owner: 'github'
       package-name: 'test-package'
@@ -226,7 +231,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete 3 oldest versions excluding major versions as per semver
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with: 
       package-name: 'test-package'
       package-type: 'npm'
@@ -243,7 +248,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete 3 oldest versions excluding major versions as per semver from a repo not having access to package
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with: 
       owner: 'github'
       package-name: 'test-package'
@@ -264,7 +269,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete all except latest 2 versions of a package hosted
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       package-name: 'test-package'
       package-type: 'npm'
@@ -280,7 +285,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete all except latest 2 versions of a package hosted from a repo not having access to package
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       owner: 'github'
       package-name: 'test-package'
@@ -300,7 +305,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete the oldest 3 version of a package hosted
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       package-name: 'test-package'
       package-type: 'npm'
@@ -316,7 +321,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   Delete the oldest 3 version of a package hosted from a repo not having access to package
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       owner: 'github'
       package-name: 'test-package'
@@ -334,7 +339,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   __Example__
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       package-name: 'test-package'
       package-type: 'npm'
@@ -345,7 +350,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   __Example__
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       owner: 'github'
       package-name: 'test-package'
@@ -364,7 +369,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   __Example__
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       package-version-ids: 'MDE0OlBhY2thZ2VWZXJzaW9uOTcyMDY3'
       package-name: 'test-package'
@@ -378,7 +383,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   __Example__
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       package-version-ids: 'MDE0OlBhY2thZ2VWZXJzaW9uOTcyMDY3'
       package-name: 'test-package'
@@ -397,7 +402,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   __Example__
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       package-version-ids: 'MDE0OlBhY2thZ2VWZXJzaW9uOTcyMDY3, MDE0OlBhY2thZ2VWZXJzaW9uOTcyMzQ5, MDE0OlBhY2thZ2VWZXJzaW9uOTcyMzUw'
       package-name: 'test-package'
@@ -411,7 +416,7 @@ This is a fork of https://github.com/actions/delete-package-versions.
   __Example__
 
   ```yaml
-  - uses: aegenet/delete-package-versions@v5.3.0
+  - uses: aegenet/delete-package-versions@v5.4.0
     with:
       package-version-ids: 'MDE0OlBhY2thZ2VWZXJzaW9uOTcyMDY3, MDE0OlBhY2thZ2VWZXJzaW9uOTcyMzQ5, MDE0OlBhY2thZ2VWZXJzaW9uOTcyMzUw'
       package-name: 'test-package'

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,14 @@ inputs:
       Regex pattern for package versions to ignore.
       Defaults to delete all versions.
     required: false
-    default: "^$"
+    default: ""
+
+  include-versions:
+    description: >
+      Regex pattern for package versions to include.
+      Defaults to include all versions.
+    required: false
+    default: ""
 
   delete-only-pre-release-versions:
     description: >

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,11 +1,12 @@
 export interface InputParams {
-  packageVersionIds?: string[]
+  packageVersionIds?: number[]
   owner?: string
   packageName?: string
   packageType?: string
   numOldVersionsToDelete?: number
   minVersionsToKeep?: number
-  ignoreVersions?: RegExp
+  ignoreVersions?: RegExp | null
+  includeVersions?: RegExp | null
   token?: string
   deletePreReleaseVersions?: boolean
   deleteUntaggedVersions?: boolean
@@ -21,6 +22,7 @@ const defaultParams = {
   numOldVersionsToDelete: 0,
   minVersionsToKeep: 0,
   ignoreVersions: new RegExp(''),
+  includeVersions: null,
   deletePreReleaseVersions: false,
   token: '',
   deleteUntaggedVersions: false,
@@ -29,13 +31,14 @@ const defaultParams = {
 }
 
 export class Input {
-  packageVersionIds: string[]
+  packageVersionIds: number[]
   owner: string
   packageName: string
   packageType: string
   numOldVersionsToDelete: number
   minVersionsToKeep: number
-  ignoreVersions: RegExp
+  ignoreVersions: RegExp | null
+  includeVersions: RegExp | null
   deletePreReleaseVersions: boolean
   token: string
   numDeleted: number
@@ -53,6 +56,7 @@ export class Input {
     this.numOldVersionsToDelete = validatedParams.numOldVersionsToDelete
     this.minVersionsToKeep = validatedParams.minVersionsToKeep
     this.ignoreVersions = validatedParams.ignoreVersions
+    this.includeVersions = validatedParams.includeVersions
     this.deletePreReleaseVersions = validatedParams.deletePreReleaseVersions
     this.token = validatedParams.token
     this.numDeleted = 0

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,14 @@ import {deleteVersions, sleep} from './delete'
 export const PACKAGE_SLEEP_MS = 15000
 
 function getActionInput(packageName: string): Input {
+  const includeVersions = getInput('include-versions')
+  const ignoreVersions = getInput('ignore-versions')
+
   return new Input({
     packageVersionIds: getInput('package-version-ids')
-      ? getInput('package-version-ids').split(',')
+      ? getInput('package-version-ids')
+          .split(',')
+          .map(f => parseInt(f, 10))
       : [],
     owner: getInput('owner') ? getInput('owner') : context.repo.owner,
     packageName,
@@ -19,7 +24,10 @@ function getActionInput(packageName: string): Input {
       10
     ),
     minVersionsToKeep: parseInt(getInput('min-versions-to-keep'), 10),
-    ignoreVersions: new RegExp(getInput('ignore-versions')),
+    ignoreVersions: ignoreVersions
+      ? new RegExp(getInput('ignore-versions'))
+      : null,
+    includeVersions: includeVersions ? new RegExp(includeVersions) : null,
     deletePreReleaseVersions: toBoolean(
       getInput('delete-only-pre-release-versions')
     ),


### PR DESCRIPTION
`include-versions` is the counterpart to `ignore-versions`, allowing to specify a regex that will include certain versions.

```yaml
# The package versions to include from deletion.
# Takes regex for the version name as input.
# By default all versions are included
include-versions:

```